### PR TITLE
Enable CORS

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "babel": "^6.0.15",
     "babel-core": "^6.1.2",
     "babel-preset-es2015": "^6.1.2",
+    "cors": "^2.7.1",
     "express": "^4.13.3",
     "gunzip-maybe": "^1.2.1",
     "lru-cache": "^2.7.0",

--- a/server.js
+++ b/server.js
@@ -6,8 +6,10 @@ var serveNPMPackageFile = require('./modules/serveNPMPackageFile').default
 
 var port = process.env.PORT || process.env.npm_package_config_port
 var app = express()
+var cors = require('cors')
 
 app.disable('x-powered-by')
+app.use(cors())
 app.use(express.static('public', { maxAge: 60000 }))
 app.use(serveNPMPackageFile)
 


### PR DESCRIPTION
Simple fix to enable CORS. Could be scoped more selectively - see https://github.com/expressjs/cors for options. Tested locally and works. 