### PR TITLE
Automatically generate bower.zip package based on bower.json, fixes #6 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,16 @@ npm-http-server recognizes URLs in the format `/package@version/path/to/file` wh
     package         The @scope/name of an npm package (scope is optional)
     version         The version, version range, or tag
     /path/tofile    The path to a file in that package (optional, defaults to main module)
+
+### Bower package url format
+
+npm-http-server recognizes a special path to serveBower packages `/package@version/bower.zip` where:
+
+    package         The @scope/name of an npm package (scope is optional)
+    version         The version, version range, or tag
+
+`bower.zip` file is created dynamically based on `bower.json` found within a package.
+It contains of, actually, `bower.json` and all files, listed in its `main` section.
+
+Version number is replaced with the one from `package.json` so there is no need
+to manually update it.

--- a/README.md
+++ b/README.md
@@ -27,10 +27,8 @@ npm-http-server recognizes URLs in the format `/package@version/path/to/file` wh
 
 ### Bower package url format
 
-npm-http-server recognizes a special path to serveBower packages `/package@version/bower.zip` where:
-
-    package         The @scope/name of an npm package (scope is optional)
-    version         The version, version range, or tag
+npm-http-server recognizes a special path to serve Bower packages - `/bower.zip`.
+Rest of the URL follows the same convention as any other file.
 
 `bower.zip` file is created dynamically based on `bower.json` found within a package.
 It contains of, actually, `bower.json` and all files, listed in its `main` section.

--- a/modules/createBowerPackage.js
+++ b/modules/createBowerPackage.js
@@ -1,55 +1,69 @@
-import { join as joinPaths} from 'path'
+import { join as joinPaths } from 'path'
 import { stat as statFile, readFile, createWriteStream } from 'fs'
 import getProperty from './getProperty'
 import archiver from 'archiver'
 
-
-const promisify = func => (...args) =>
-  new Promise((resolve, reject) =>
-    func(...args, (error, data) => error ? reject(error) : resolve(data)))
+function promisify(func) {
+  return function (...args) {
+    return new Promise(function (resolve, reject) {
+      func(...args, function (error, data) {
+        error ? reject(error) : resolve(data)
+      })
+    })
+  }
+}
 
 const readFilePromised = promisify(readFile)
 const statFilePromised = promisify(statFile)
 
-const tryToFinish = ({ tarballDir }) =>
+function tryToFinish({ tarballDir }) {
   Promise.all([
       readFilePromised(joinPaths(tarballDir, 'bower.json'), 'utf8'),
       readFilePromised(joinPaths(tarballDir, 'package.json'), 'utf8')
     ])
-    .then(([ bowerJson, packageJson ]) => {
+    .then(function ([ bowerJson, packageJson ]) {
       const bowerConfig = Object.assign(JSON.parse(bowerJson), { version: packageJson.version })
       const main = getProperty(bowerConfig, 'main')
       const files = Array.isArray(main) ? main : [ main ]
       const bowerZip = joinPaths(tarballDir, 'bower.zip')
       const out = createWriteStream(bowerZip)
 
-      return new Promise((resolve, reject) => {
+      return new Promise(function (resolve, reject) {
         const zip = archiver('zip', {})
         zip.on('error', reject)
         zip.pipe(out)
         out.on('error', reject)
-        out.on('finish', () => resolve(bowerZip))
+        out.on('finish', function () {
+          resolve(bowerZip)
+        })
 
         // add `bower.json` file with updated version
         zip.append(JSON.stringify(bowerConfig, null, 2), { name: 'bower.json' })
 
         // add all files from `main` section of Bower config
-        files.forEach(file => zip.file(joinPaths(tarballDir, file), { name: file }))
+        files.forEach(function (file) {
+          zip.file(joinPaths(tarballDir, file), { name: file })
+        })
         zip.finalize()
       })
     })
+}
 
-const createBowerPackage = ({ tarballDir }, callback) =>
+function createBowerPackage({ tarballDir }, callback) {
   statFilePromised(joinPaths(tarballDir, 'bower.json'))
-    .then(stat => {
+    .then(function (stat) {
       if (!stat.isFile()) {
         throw new Error('bower.json is not a file')
       }
       return tryToFinish({ tarballDir })
-        .then(bowerZip => callback(null, bowerZip))
+        .then(function (bowerZip) {
+          callback(null, bowerZip)
+        })
         .catch(callback)
     })
-    .catch(() => callback(new Error('bower.json is required to create bower.zip package')))
-
+    .catch(function () {
+      callback(new Error('bower.json is required to create bower.zip package'))
+    })
+}
 
 export default createBowerPackage

--- a/modules/createBowerPackage.js
+++ b/modules/createBowerPackage.js
@@ -1,0 +1,49 @@
+import { join as joinPaths} from 'path'
+import { stat as statFile, readFile, createWriteStream } from 'fs'
+import getProperty from './getProperty'
+import archiver from 'archiver'
+
+
+const promisify = func => (...args) =>
+  new Promise((resolve, reject) =>
+    func(...args, (error, data) => error ? reject(error) : resolve(data)))
+
+const readFilePromised = promisify(readFile)
+const statFilePromised = promisify(statFile)
+
+const tryToFinish = ({ tarballDir }) =>
+  Promise.all([
+      readFilePromised(joinPaths(tarballDir, 'bower.json'), 'utf8'),
+      readFilePromised(joinPaths(tarballDir, 'package.json'), 'utf8')
+    ])
+    .then(([ bowerJson ]) => {
+      const main = getProperty(JSON.parse(bowerJson), 'main')
+      const files = [ 'bower.json' ].concat(Array.isArray(main) ? main : [ main ])
+      const bowerZip = joinPaths(tarballDir, 'bower.zip')
+      const out = createWriteStream(bowerZip)
+
+      return new Promise((resolve, reject) => {
+        const zip = archiver('zip', {})
+        zip.on('error', reject)
+        zip.pipe(out)
+        out.on('error', reject)
+        out.on('finish', () => resolve(bowerZip))
+        files.forEach(file => zip.file(joinPaths(tarballDir, file), { name: file }))
+        zip.finalize()
+      })
+    })
+
+const createBowerPackage = ({ tarballDir }, callback) =>
+  statFilePromised(joinPaths(tarballDir, 'bower.json'))
+    .then(stat => {
+      if (!stat.isFile()) {
+        throw new Error('bower.json is not a file')
+      }
+      return tryToFinish({ tarballDir })
+        .then(bowerZip => callback(null, bowerZip))
+        .catch(callback)
+    })
+    .catch(() => callback(new Error('bower.json is required to create bower.zip package')))
+
+
+export default createBowerPackage

--- a/modules/serveNPMPackageFile.js
+++ b/modules/serveNPMPackageFile.js
@@ -13,7 +13,7 @@ import getProperty from './getProperty'
 import getMaxAge from './getMaxAge'
 import createBowerPackage from './createBowerPackage'
 
-const bowerBundle = process.env.BOWER_BUNDLE || process.env.npm_package_config_bowerBundle
+const BOWER_BUNDLE = process.env.BOWER_BUNDLE || process.env.npm_package_config_bowerBundle
 
 const TmpDir = tmpdir()
 
@@ -46,7 +46,7 @@ function serveNPMPackageFile(req, res) {
   let tarballDir = joinPaths(TmpDir, packageName + '-' + version)
 
   function tryToFinish() {
-    if (filename === bowerBundle) {
+    if (filename === BOWER_BUNDLE) {
       createBowerPackage({ tarballDir }, function (error, file) {
         if (error) {
           sendServerError(res, error)

--- a/modules/serveNPMPackageFile.js
+++ b/modules/serveNPMPackageFile.js
@@ -11,6 +11,9 @@ import getPackage from './getPackage'
 import resolveFile from './resolveFile'
 import getProperty from './getProperty'
 import getMaxAge from './getMaxAge'
+import createBowerPackage from './createBowerPackage'
+
+const bowerBundle = process.env.BOWER_BUNDLE || process.env.npm_package_config_bowerBundle
 
 const TmpDir = tmpdir()
 
@@ -43,7 +46,18 @@ function serveNPMPackageFile(req, res) {
   let tarballDir = joinPaths(TmpDir, packageName + '-' + version)
 
   function tryToFinish() {
-    if (filename) {
+    if (filename === bowerBundle) {
+      createBowerPackage({ tarballDir }, function (error, file) {
+        if (error) {
+          sendServerError(res, error)
+        } else if (file === null) {
+          sendNotFoundError(res,
+            `could not generate bower.zip for package ${packageName}@${version}`)
+        } else {
+          sendFile(res, file, getMaxAge(version))
+        }
+      })
+    } else if (filename) {
       const file = joinPaths(tarballDir, filename)
 
       resolveFile(file, function (error, file) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "author": "Michael Jackson",
   "config": {
     "registryURL": "https://registry.npmjs.org",
-    "port": 5000
+    "port": 5000,
+    "bowerBundle": "/bower.zip"
   },
   "scripts": {
     "lint": "eslint .",
@@ -27,6 +28,7 @@
     "tar-fs": "^1.8.1"
   },
   "devDependencies": {
+    "archiver": "^0.20.0",
     "babel-eslint": "^4.1.3",
     "eslint": "^1.7.3",
     "eslint-plugin-react": "^3.6.3",

--- a/public/index.html
+++ b/public/index.html
@@ -73,7 +73,7 @@
       <p>Then use <code>bower install https://npmcdn.com/my-package-name/bower.zip</code> to install package</p>
       <ul>
         <li><a href="/react-swap/bower.zip">https://npmcdn.com/react-swap/bower.zip</a></li>
-        <li><a href="/react-swap@1.4.0/bower.zip">https://npmcdn.com/react-swap@1.4.0/bower.zip</a></li>
+        <li><a href="/react-collapse@1.6.3/bower.zip">https://npmcdn.com/react-collapse@1.6.3/bower.zip</a></li>
       </ul>
 
 

--- a/public/index.html
+++ b/public/index.html
@@ -66,6 +66,18 @@
         <li><a href="/angular-formly">https://npmcdn.com/angular-formly</a></li>
       </ul>
 
+
+      <h3>Bower packages</h3>
+      <p>If your package has bower.json config, npmcdn can generate Bower package on the fly, so there is no need to keep pre-compiled library in your GitHub repository. Simply request <code>/bower.zip</code> file and it will be generated based on bower.json's <code>main</code> list of files, maintaining all sub-folders.</p>
+
+      <p>Then use <code>bower install https://npmcdn.com/my-package-name/bower.zip</code> to install package</p>
+      <ul>
+        <li><a href="/react-swap/bower.zip">https://npmcdn.com/react-swap/bower.zip</a></li>
+        <li><a href="/react-swap@1.4.0/bower.zip">https://npmcdn.com/react-swap@1.4.0/bower.zip</a></li>
+      </ul>
+
+
+
       <h3>Query Parameters</h3>
       <table cellpadding="0" cellspacing="0">
         <thead>


### PR DESCRIPTION
I am going to add unit tests for this one bit later.

Logic is straightforward:
1. request `bower.zip` (configurable bower package filename)
2. parse bower.json for files from `main` section
3. create `bower.zip` that contains all files from `main` section + bower.json file itself
4. serves it as any other file


Currently zip is corrupted (blocked by #16) but works fine with those changes.


Note: I used ES6 promises and ES6 syntax to simplify code, but if necessary, can easily convert it back to match rest of the code (I did it initially but code looked much bigger)


URL parsing is not changed. URL examples:

https://npmcdn.com/react@0.14.2/bower.zip
https://npmcdn.com/react-dom@0.14.2/bower.zip
https://npmcdn.com/history@1.12.5/bower.zip
https://npmcdn.com/react-router@1.0.0/bower.zip


Usage with bower:

```
bower install https://npmcdn.com/react@0.14.2/bower.zip
```

TODO: 
1. Unit tests
2. README update