### PR TITLE
Change resolveFile find directory index files.

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -70,12 +70,14 @@ function getMaxAge(packageVersion) {
   return OneYear
 }
 
-const ResolveExtensions = [ '', '.js', '.json' ]
+const ResolveExtensions = [ '', '.js', '.json', '.html' ]
 
 /**
- * Resolves a path like "lib/index" into "lib/index.js" or
- * "lib/index.json" depending on which one is available, similar
+ * Resolves a path like "lib/index" into "lib/index[.ResolveExtension]"
+ * depending on which one is available, similar
  * to how require('lib/index') does.
+ *
+ * In addition, resolves a path like "lib" into "lib/index[.ResolveExtension]".
  */
 function resolveFile(file, callback) {
   ResolveExtensions.reduceRight(function (next, ext) {
@@ -83,6 +85,8 @@ function resolveFile(file, callback) {
       statFile(file + ext, function (error, stat) {
         if (stat && stat.isFile()) {
           callback(null, file + ext)
+        } else if (stat && stat.isDirectory()) {
+          resolveFile(joinPaths(file, 'index'), callback)
         } else if (error && error.code !== 'ENOENT') {
           callback(error)
         } else {


### PR DESCRIPTION
Fix `"main":"lib"`. Returns a 404 `Not found: file "lib" in package victorica@0.0.2` But exsits a `lib/index.js`.

>
https://github.com/59naga/victorica/blob/v0.0.2/package.json#L6
-> https://npmcdn.com/victorica@0.0.2 (404 Not found: file "lib" in package victorica@0.0.2)

And add `.html` to `ResolveExtensions`. Can publish the document on the `npmcdn.com`.

e.g.

https://npmcdn.com/immaterial-design-ripple/esdoc/ (404)
-> https://npmcdn.com/immaterial-design-ripple/esdoc/index.html