### PR TITLE
Fix directory listing urls

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -126,13 +126,18 @@ export const createRequestHandler = (options = {}) => {
           } else if (autoIndex) {
             statFile(filepath, (error, stats) => {
               if (stats && stats.isDirectory()) {
-                generateDirectoryIndexHTML(tarballDir, filename, displayName, (error, html) => {
-                  if (html) {
-                    sendHTML(res, html, OneYear)
-                  } else {
-                    sendServerError(res, `unable to generate index page for ${displayName}${filename}`)
-                  }
-                })
+                // Append `/` to directory urls
+                if(req.url[req.url.length - 1] !== '/') {
+                  sendRedirect(res, req.url + '/', redirectTTL)
+                } else {
+                  generateDirectoryIndexHTML(tarballDir, filename, displayName, (error, html) => {
+                    if (html) {
+                      sendHTML(res, html, OneYear)
+                    } else {
+                      sendServerError(res, `unable to generate index page for ${displayName}${filename}`)
+                    }
+                  })
+                }
               } else {
                 sendNotFoundError(res, `file "${filename}" in package ${displayName}`)
               }


### PR DESCRIPTION
Currently, if you access a directory without the trailing slash, the relative links are broken, as the browser recognises the page as a file and resolves the link to the parent folder.

For example, the `react.js` link on https://npmcdn.com/react@0.14.2/dist points to https://npmcdn.com/react@0.14.2/react.js instead of https://npmcdn.com/react@0.14.2/dist/react.js

This PR adds a redirect which appends the trailing slash to the url when we're serving a directory without it.