### PR TITLE
Add support for getting a recursive json file listing

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,7 @@
     "no-confusing-arrow": 0,
     "no-param-reassign": [2, { "props": false }],
     "no-shadow": 1,
+    "no-use-before-define": 1,
     "prefer-template": 0,
     "react/prefer-es6-class": 0,
     "react/prop-types": 0,

--- a/modules/PackageUtils.js
+++ b/modules/PackageUtils.js
@@ -11,7 +11,8 @@ const decodeParam = (param) =>
   param && decodeURIComponent(param)
 
 const ValidQueryKeys = {
-  main: true
+  main: true,
+  json: true
 }
 
 const queryIsValid = (query) =>
@@ -34,6 +35,7 @@ export const parsePackageURL = (url) => {
 
   return {        // If the URL is /@scope/name@version/path.js?bundle:
     packageName,  // @scope/name
+    pathname,     // /@scope/name@version/path.js
     version,      // version
     filename,     // /path.js
     search,       // ?main=browser

--- a/modules/ResponseUtils.js
+++ b/modules/ResponseUtils.js
@@ -11,7 +11,7 @@ export const sendText = (res, statusCode, text) => {
 }
 
 export const sendJSON = (res, json, maxAge = 0, statusCode = 200) => {
-  const text = JSON.stringify(json, null, 2)
+  const text = JSON.stringify(json)
 
   res.writeHead(statusCode, {
     'Content-Type': 'application/json',

--- a/modules/ResponseUtils.js
+++ b/modules/ResponseUtils.js
@@ -10,6 +10,18 @@ export const sendText = (res, statusCode, text) => {
   res.end(text)
 }
 
+export const sendJSON = (res, json, maxAge = 0, statusCode = 200) => {
+  const text = JSON.stringify(json, null, 2);
+  
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json',
+    'Content-Length': text.length,
+    'Cache-Control': `public, max-age=${maxAge}`
+  })
+
+  res.end(text)
+}
+
 export const sendInvalidURLError = (res, url) =>
   sendText(res, 403, `Invalid URL: ${url}`)
 

--- a/modules/ResponseUtils.js
+++ b/modules/ResponseUtils.js
@@ -11,8 +11,8 @@ export const sendText = (res, statusCode, text) => {
 }
 
 export const sendJSON = (res, json, maxAge = 0, statusCode = 200) => {
-  const text = JSON.stringify(json, null, 2);
-  
+  const text = JSON.stringify(json, null, 2)
+
   res.writeHead(statusCode, {
     'Content-Type': 'application/json',
     'Content-Length': text.length,

--- a/modules/TreeUtils.js
+++ b/modules/TreeUtils.js
@@ -50,7 +50,7 @@ const resolveEntry = (baseDir, path, stats, maximumDepth) =>
       lastModified: new Date(stats.mtime).toISOString(),
       mime: getContentType(path),
       size: stats.size,
-      type: getType(stats),
+      contentType: getType(stats),
     })
 
 const getEntries = (baseDir, name, maximumDepth) =>

--- a/modules/TreeUtils.js
+++ b/modules/TreeUtils.js
@@ -13,6 +13,46 @@ const getStats = (file) =>
     })
   })
 
+const getType = stats => {
+  if (stats.isFile()) return 'file'
+  if (stats.isDirectory()) return 'directory'
+  if (stats.isBlockDevice()) return 'blockDevice'
+  if (stats.isCharacterDevice()) return 'characterDevice'
+  if (stats.isSymbolicLink()) return 'symlink'
+  if (stats.isFIFO()) return 'fifo'
+  if (stats.isSocket()) return 'socket'
+  return 'unknown'
+}
+
+const resolveDirectory = (baseDir, path, stats, maximumDepth) => {
+  const children = maximumDepth > 0
+    ? getEntries(baseDir, path, maximumDepth - 1)
+    : Promise.resolve(null)
+
+  return children
+    .then(
+      children => ({
+        path,
+        lastModified: new Date(stats.mtime).toISOString(),
+        mime: getContentType(path),
+        size: stats.size,
+        type: getType(stats),
+        children
+      })
+    )
+}
+
+const resolveEntry = (baseDir, path, stats, maximumDepth) =>
+  stats.isDirectory()
+    ? resolveDirectory(baseDir, path, stats, maximumDepth)
+    : Promise.resolve({
+      path,
+      lastModified: new Date(stats.mtime).toISOString(),
+      mime: getContentType(path),
+      size: stats.size,
+      type: getType(stats),
+    })
+
 const getEntries = (baseDir, name, maximumDepth) =>
   new Promise((resolve, reject) => {
     const dir = path.join(baseDir, name)
@@ -32,46 +72,6 @@ const getEntries = (baseDir, name, maximumDepth) =>
       }
     })
   })
-
-const getType = stats => {
-  if (stats.isFile()) return 'file';
-  if (stats.isDirectory()) return 'directory';
-  if (stats.isBlockDevice()) return 'blockDevice';
-  if (stats.isCharacterDevice()) return 'characterDevice';
-  if (stats.isSymbolicLink()) return 'symlink';
-  if (stats.isFIFO()) return 'fifo';
-  if (stats.isSocket()) return 'socket';
-  return 'unknown';
-}
-
-const resolveDirectory = (baseDir, path, stats, maximumDepth) => {
-  const children = maximumDepth > 0
-    ? getEntries(baseDir, path, maximumDepth - 1)
-    : Promise.resolve(null);
-  
-  return children
-    .then(
-      children => ({
-        path,
-        lastModified: new Date(stats.mtime).toISOString(),
-        mime: getContentType(path),
-        size: stats.size,
-        type: getType(stats),
-        children
-      })
-    )
-}
-
-const resolveEntry = (baseDir, path, stats, maximumDepth) =>
-  stats.isDirectory()
-    ? resolveDirectory(baseDir, path, stats, maximumDepth)
-    : Promise.resolve({
-        path,
-        lastModified: new Date(stats.mtime).toISOString(),
-        mime: getContentType(path),
-        size: stats.size,
-        type: getType(stats),
-      })
 
 
 export const generateDirectoryTree = (baseDir, dir, maximumDepth, callback) =>

--- a/modules/TreeUtils.js
+++ b/modules/TreeUtils.js
@@ -1,0 +1,79 @@
+import fs from 'fs'
+import path from 'path'
+import { getContentType } from './ResponseUtils'
+
+const getStats = (file) =>
+  new Promise((resolve, reject) => {
+    fs.lstat(file, (error, stats) => {
+      if (error) {
+        reject(error)
+      } else {
+        resolve(stats)
+      }
+    })
+  })
+
+const getEntries = (baseDir, name, maximumDepth) =>
+  new Promise((resolve, reject) => {
+    const dir = path.join(baseDir, name)
+    fs.readdir(dir, (error, files) => {
+      if (error) {
+        reject(error)
+      } else {
+        resolve(
+          Promise.all(
+            files.map(file => getStats(path.join(dir, file)))
+          ).then(
+            statsArray => Promise.all(statsArray.map(
+              (stats, index) => resolveEntry(baseDir, path.join(name, files[index]), stats, maximumDepth)
+            ))
+          )
+        )
+      }
+    })
+  })
+
+const getType = stats => {
+  if (stats.isFile()) return 'file';
+  if (stats.isDirectory()) return 'directory';
+  if (stats.isBlockDevice()) return 'blockDevice';
+  if (stats.isCharacterDevice()) return 'characterDevice';
+  if (stats.isSymbolicLink()) return 'symlink';
+  if (stats.isFIFO()) return 'fifo';
+  if (stats.isSocket()) return 'socket';
+  return 'unknown';
+}
+
+const resolveDirectory = (baseDir, path, stats, maximumDepth) => {
+  const children = maximumDepth > 0
+    ? getEntries(baseDir, path, maximumDepth - 1)
+    : Promise.resolve(null);
+  
+  return children
+    .then(
+      children => ({
+        path,
+        lastModified: new Date(stats.mtime).toISOString(),
+        mime: getContentType(path),
+        size: stats.size,
+        type: getType(stats),
+        children
+      })
+    )
+}
+
+const resolveEntry = (baseDir, path, stats, maximumDepth) =>
+  stats.isDirectory()
+    ? resolveDirectory(baseDir, path, stats, maximumDepth)
+    : Promise.resolve({
+        path,
+        lastModified: new Date(stats.mtime).toISOString(),
+        mime: getContentType(path),
+        size: stats.size,
+        type: getType(stats),
+      })
+
+
+export const generateDirectoryTree = (baseDir, dir, maximumDepth, callback) =>
+  getEntries(baseDir, dir, maximumDepth)
+    .then(json => callback(null, json), callback)

--- a/modules/TreeUtils.js
+++ b/modules/TreeUtils.js
@@ -25,19 +25,19 @@ const getType = stats => {
 }
 
 const resolveDirectory = (baseDir, path, stats, maximumDepth) => {
-  const children = maximumDepth > 0
+  const files = maximumDepth > 0
     ? getEntries(baseDir, path, maximumDepth - 1)
     : Promise.resolve(null)
 
-  return children
+  return files
     .then(
-      children => ({
+      files => ({
         path,
         lastModified: new Date(stats.mtime).toISOString(),
         mime: getContentType(path),
         size: stats.size,
         type: getType(stats),
-        children
+        files
       })
     )
 }
@@ -76,4 +76,4 @@ const getEntries = (baseDir, name, maximumDepth) =>
 
 export const generateDirectoryTree = (baseDir, dir, maximumDepth, callback) =>
   getEntries(baseDir, dir, maximumDepth)
-    .then(json => callback(null, json), callback)
+    .then(files => callback(null, { files }), callback)

--- a/modules/index.js
+++ b/modules/index.js
@@ -1,3 +1,4 @@
+import accepts from 'accepts'
 import http from 'http'
 import tmpdir from 'os-tmpdir'
 import { parse as parseURL } from 'url'
@@ -6,6 +7,7 @@ import { stat as statFile, readFile } from 'fs'
 import { maxSatisfying as maxSatisfyingVersion } from 'semver'
 import { parsePackageURL, createPackageURL, getPackage } from './PackageUtils'
 import { generateDirectoryIndexHTML } from './IndexUtils'
+import { generateDirectoryTree } from './TreeUtils'
 import { getPackageInfo } from './RegistryUtils'
 import { createBowerPackage } from './BowerUtils'
 import {
@@ -15,6 +17,7 @@ import {
   sendRedirect,
   sendFile,
   sendText,
+  sendJSON,
   sendHTML
 } from './ResponseUtils'
 
@@ -92,6 +95,7 @@ export const createRequestHandler = (options = {}) => {
   const bowerBundle = options.bowerBundle || '/bower.zip'
   const redirectTTL = options.redirectTTL || 0
   const autoIndex = options.autoIndex !== false
+  const maximumDepth = options.maximumDepth || Number.MAX_VALUE
 
   const handleRequest = (req, res) => {
     const url = parsePackageURL(req.url)
@@ -130,13 +134,26 @@ export const createRequestHandler = (options = {}) => {
                 if (req.url[req.url.length - 1] !== '/') {
                   sendRedirect(res, req.url + '/', redirectTTL)
                 } else {
-                  generateDirectoryIndexHTML(tarballDir, filename, displayName, (error, html) => {
-                    if (html) {
-                      sendHTML(res, html, OneYear)
-                    } else {
-                      sendServerError(res, `unable to generate index page for ${displayName}${filename}`)
-                    }
-                  })
+                  const accept = accepts(req)
+                  const prefer = accept.type(['html', 'json'])
+                  
+                  if (prefer === 'json') {
+                    generateDirectoryTree(tarballDir, filename, maximumDepth, (error, json) => {
+                      if (json) {
+                        sendJSON(res, json, OneYear)
+                      } else {
+                        sendServerError(res, `unable to generate index json for ${displayName}${filename}`)
+                      }
+                    })
+                  } else {
+                    generateDirectoryIndexHTML(tarballDir, filename, displayName, (error, html) => {
+                      if (html) {
+                        sendHTML(res, html, OneYear)
+                      } else {
+                        sendServerError(res, `unable to generate index page for ${displayName}${filename}`)
+                      }
+                    })
+                  }
                 }
               } else {
                 sendNotFoundError(res, `file "${filename}" in package ${displayName}`)

--- a/modules/index.js
+++ b/modules/index.js
@@ -135,8 +135,8 @@ export const createRequestHandler = (options = {}) => {
                   sendRedirect(res, req.url + '/', redirectTTL)
                 } else {
                   const accept = accepts(req)
-                  const prefer = accept.type(['html', 'json'])
-                  
+                  const prefer = accept.type([ 'html', 'json' ])
+
                   if (prefer === 'json') {
                     generateDirectoryTree(tarballDir, filename, maximumDepth, (error, json) => {
                       if (json) {

--- a/modules/index.js
+++ b/modules/index.js
@@ -1,4 +1,3 @@
-import accepts from 'accepts'
 import http from 'http'
 import tmpdir from 'os-tmpdir'
 import { parse as parseURL } from 'url'
@@ -134,10 +133,7 @@ export const createRequestHandler = (options = {}) => {
                 if (url.pathname[url.pathname.length - 1] !== '/') {
                   sendRedirect(res, url.pathname + '/' + url.search, redirectTTL)
                 } else {
-                  const accept = accepts(req)
-                  const prefer = accept.type([ 'html', 'json' ])
-
-                  if (prefer === 'json') {
+                  if (url.query.hasOwnProperty('json')) {
                     generateDirectoryTree(tarballDir, filename, maximumDepth, (error, json) => {
                       if (json) {
                         sendJSON(res, json, OneYear)

--- a/modules/index.js
+++ b/modules/index.js
@@ -131,8 +131,8 @@ export const createRequestHandler = (options = {}) => {
             statFile(filepath, (error, stats) => {
               if (stats && stats.isDirectory()) {
                 // Append `/` to directory URLs
-                if (req.url[req.url.length - 1] !== '/') {
-                  sendRedirect(res, req.url + '/', redirectTTL)
+                if (url.pathname[url.pathname.length - 1] !== '/') {
+                  sendRedirect(res, url.pathname + '/' + url.search, redirectTTL)
                 } else {
                   const accept = accepts(req)
                   const prefer = accept.type([ 'html', 'json' ])

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
+    "accepts": "^1.3.3",
     "archiver": "^1.0.0",
     "byte-size": "^2.0.0",
     "csso": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "accepts": "^1.3.3",
     "archiver": "^1.0.0",
     "byte-size": "^2.0.0",
     "csso": "^2.0.0",


### PR DESCRIPTION
This PR adds a json listing of files based on content-negotiation.

The current behaviour remains untouched _except_ when a request for a directory has an `Accept` header that favours `json` over `html`. In this case, a new `TreeUtils` tool is used to construct and respond with a JSON representation of the contents of that version of the package. The recursion depth for this is configurable but defaults to `Number.MAX_VALUE`.

The format of the json looks like this:
```json
[
  {
    "path": "/.c9revisions",
    "lastModified": "2016-05-20T12:13:02.000Z",
    "mime": "application/octet-stream",
    "size": 136,
    "type": "directory",
    "children": [
      {
        "path": "/.c9revisions/README.md.c9save",
        "lastModified": "2013-03-26T21:59:05.000Z",
        "mime": "application/octet-stream",
        "size": 1233,
        "type": "file"
      },
      {
        "path": "/.c9revisions/index.js.c9save",
        "lastModified": "2013-03-26T21:59:22.000Z",
        "mime": "application/octet-stream",
        "size": 988,
        "type": "file"
      }
    ]
  },
  {
    "path": "/.npmignore",
    "lastModified": "2013-03-26T21:51:43.000Z",
    "mime": "text/plain",
    "size": 84,
    "type": "file"
  },
  {
    "path": "/README.md",
    "lastModified": "2013-03-26T21:59:04.000Z",
    "mime": "text/x-markdown",
    "size": 694,
    "type": "file"
  },
  {
    "path": "/index.js",
    "lastModified": "2013-03-26T21:59:22.000Z",
    "mime": "application/javascript",
    "size": 387,
    "type": "file"
  },
  {
    "path": "/package.json",
    "lastModified": "2013-03-26T22:00:38.000Z",
    "mime": "application/json",
    "size": 441,
    "type": "file"
  }
]
```

I considered making the depth configurable by query parameter but would like your feedback. This API would be used by Plunker as a replacement for its (deficient) package manager so that:

1. Users can find npm packages using the registry apis; then
2. Select which files from the selected package(s) they would like to import; then
3. Inject appropriate markup in `index.html` and `package.json` entries to refer to https://npmcdn.com.